### PR TITLE
fix: `ends-with` fails on longer substrings

### DIFF
--- a/packages/string/src/_ends-with.sass
+++ b/packages/string/src/_ends-with.sass
@@ -25,6 +25,11 @@
 	@if meta.type-of($end-at) != 'number'
 		@error $end-at
 
-	$start-at: $end-at - string.length($substring) + 1
+	$substring-length: string.length($substring)
+
+	@if $substring-length > string.length($string)
+		@return false
+
+	$start-at: $end-at - $substring-length + 1
 
 	@return index.index($string, $substring, $start-at) == $start-at

--- a/packages/string/test/_ends-with.sass
+++ b/packages/string/test/_ends-with.sass
@@ -40,6 +40,10 @@
 		$assert: src.ends-with($string, 'bcd', -3)
 		@include true.assert-equal($assert, false)
 
+	@include true.it('Does not end with longer substring')
+		$assert: src.ends-with('abc', 'abcd')
+		@include true.assert-equal($assert, false)
+
 	@include true.it('Throws when $string is not a string')
 		$assert: src.ends-with(12345, 'a')
 		$expected: 'ERROR: $string: `12345` is not a string for `ends-with()`.'


### PR DESCRIPTION
When `ends-with` is passed a substring that is longer than the string, specifically by 1 character, the computation of `start-at` is such that its resultant value is 0, which also happens to be what `index.index` returns when the substring was not found, thus incorrectly returning true. Add a check against substrings which are longer than the string, as it logically cannot ever end in a longer substring.