### PR TITLE
feat: `string.nth`

### DIFF
--- a/packages/string/index.sass
+++ b/packages/string/index.sass
@@ -8,6 +8,7 @@
 @forward 'src/index'
 @forward 'src/is-quoted'
 @forward 'src/last-index'
+@forward 'src/nth'
 @forward 'src/repeat'
 @forward 'src/replace'
 @forward 'src/split'

--- a/packages/string/src/_nth.sass
+++ b/packages/string/src/_nth.sass
@@ -1,0 +1,24 @@
+// Copyright (c) roydukkey. All rights reserved.
+// Licensed under the MIT. See LICENSE file in the project root for full license information.
+
+@use 'sass:meta'
+@use 'sass:string'
+@use '@sass-fairy/exception/src/parameter-type'
+@use '@sass-fairy/exception/src/validate-index'
+
+
+//
+// @throw `#{$string}` is not a string.
+// @throw `#{$index}` is not a number.
+//
+@function nth($string, $index)
+
+	@if meta.type-of($string) != 'string'
+		@error parameter-type.parameter-type('nth', 'string', $string, 'string')
+
+	$index: validate-index.validate-index('nth', 'index', $index, $string)
+
+	@if meta.type-of($index) != 'number'
+		@error $index
+
+	@return string.slice($string, $index, $index)

--- a/packages/string/test/_nth.sass
+++ b/packages/string/test/_nth.sass
@@ -1,0 +1,28 @@
+// Copyright (c) roydukkey. All rights reserved.
+// Licensed under the MIT. See LICENSE file in the project root for full license information.
+
+@use '@sass-fairy/string' as src
+@use 'true'
+
+
+@include true.describe('@function string.nth')
+
+	$string: 'abcde'
+
+	@include true.it('Returns the character at a positive (+) $index in $string')
+		$assert: src.nth($string, 3)
+		@include true.assert-equal($assert, 'c')
+
+	@include true.it('Returns the character at a negative (-) $index in $string')
+		$assert: src.nth($string, -2)
+		@include true.assert-equal($assert, 'd')
+
+	@include true.it('Throws when $string is not a string')
+		$assert: src.nth(12345, 1)
+		$expected: 'ERROR: $string: `12345` is not a string for `nth()`.'
+		@include true.assert-equal($assert, $expected)
+
+	@include true.it('Throws when $index is not a number')
+		$assert: src.nth($string, 'a')
+		$expected: 'ERROR: $index: `"a"` is not a number for `nth()`.'
+		@include true.assert-equal($assert, $expected)

--- a/packages/string/test/index.sass
+++ b/packages/string/test/index.sass
@@ -13,6 +13,7 @@
 @use 'from'
 @use 'includes'
 @use 'last-index'
+@use 'nth'
 @use 'repeat'
 @use 'replace'
 @use 'split'


### PR DESCRIPTION
Implements `list.nth`-like interface for strings, along with relevant unit tests.

Fixes #13